### PR TITLE
declare moduleを追記

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}


### PR DESCRIPTION
## やったこと

`vite-env-d.ts`に`declare module`を追記した

## 確認事項

`.vue`を`import`した時に`Cannot find module '@/xxx.vue' or its corresponding type declarations.ts(2307)`が表示されないこと